### PR TITLE
fix: strip @jest-environment node from production route files

### DIFF
--- a/app/api/demo/route.ts
+++ b/app/api/demo/route.ts
@@ -1,6 +1,3 @@
-/**
- * @jest-environment node
- */
 import { NextRequest, NextResponse } from "next/server"
 
 export async function POST(req: NextRequest) {

--- a/app/api/replay/route.ts
+++ b/app/api/replay/route.ts
@@ -1,6 +1,3 @@
-/**
- * @jest-environment node
- */
 import { NextRequest, NextResponse } from "next/server"
 import { getPayload } from "@/lib/db"
 

--- a/app/api/webhook/[id]/route.ts
+++ b/app/api/webhook/[id]/route.ts
@@ -1,6 +1,3 @@
-/**
- * @jest-environment node
- */
 import { NextRequest, NextResponse } from "next/server"
 import { randomUUID } from "crypto"
 import { insertPayload } from "@/lib/db"


### PR DESCRIPTION
Closes #2

Removes `@jest-environment node` JSDoc docblocks from 3 production route files:
- `app/api/webhook/[id]/route.ts`
- `app/api/replay/route.ts`
- `app/api/demo/route.ts`

These belong only in test files.